### PR TITLE
Added field named initSqlExec to JSON to specify the initialization SQL statement at the time of DB connection 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,11 +2,13 @@
 
 ## EN
 
-- TBD
+- Added field named transactionIsolation to JSON to configure isolation level like Connection.setTransactionIsolation.
+- Added field named initSqlExec to JSON to specify the initialization SQL statement at the time of DB connection (experimental).
 
 ## JA
 
-- Connection.setTransactionIsolation を JSON で指定できるように変更。
+- transactionIsolation という名前の項目を JSON に追加して Connection.setTransactionIsolation などを指定できるように変更。
+- initSqlExec という名前の項目を JSON に追加して DB接続時の初期化SQL文を指定できるようにする (experimental)。
 
 # Release 1.15 (2021-05-19)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,13 @@
+# Release 1.16 (2021-05-22)
+
+## EN
+
+- TBD
+
+## JA
+
+- Connection.setTransactionIsolation を JSON で指定できるように変更。
+
 # Release 1.15 (2021-05-19)
 
 ## EN

--- a/doc/spec-oiyokan-settings.md
+++ b/doc/spec-oiyokan-settings.md
@@ -39,6 +39,8 @@ src/main/resources/iyokan/oiyokan-settings.json
 | jdbcUser       | JDBC user name. ex: `user1`                                       |
 | jdbcPassEnc    | JDBC password with Encryption. (Recommended)                      |
 | jdbcPassPlain  | JDBC password without Encryption. (jdbcPassEnc is recommended)    |
+| transactionIsolation | Transaction Isolation. Default:`Connection.TRANSACTION_READ_COMMITTED` |
+| initSqlExec    | (experimental) Initialize sql when connect.                       |
 
 #### entitySet section
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>jp.igapyon.oiyokan</groupId>
 	<artifactId>oiyokan</artifactId>
-	<version>1.15.20210519c-SNAPSHOT</version>
+	<version>1.15.20210522a-SNAPSHOT</version>
 	<name>oiyokan</name>
 	<description>Oiyokan is a simple OData v4 Server. (based on Apache
 		Olingo / h2 database)</description>

--- a/src/main/java/jp/oiyokan/OiyokanConstants.java
+++ b/src/main/java/jp/oiyokan/OiyokanConstants.java
@@ -27,7 +27,7 @@ public class OiyokanConstants {
     /**
      * Oiyokan のバージョン番号
      */
-    public static final String VERSION = "1.15.20210519b";
+    public static final String VERSION = "1.15.20210522a";
 
     /**
      * 暗号化で利用するパスフレーズ。環境変数 OIYOKAN_PASSPHRASE で上書き動作。

--- a/src/main/java/jp/oiyokan/OiyokanMessages.java
+++ b/src/main/java/jp/oiyokan/OiyokanMessages.java
@@ -270,6 +270,7 @@ public class OiyokanMessages {
     public static final String IY7173 = "[IY7173] INFO: start to load oiyokan settings";
     public static final String IY7174 = "[IY7174] INFO: load oiyokan settings";
     public static final String IY7175 = "[IY7175] DEBUG: DB set connection transaction isolation.";
+    public static final String IY7176 = "[IY7176] DEBUG: DB init sql exec.";
 
     ////////////////////////////////////////////////////////////////////////////////
     // Authz (Server Side)

--- a/src/main/java/jp/oiyokan/OiyokanMessages.java
+++ b/src/main/java/jp/oiyokan/OiyokanMessages.java
@@ -256,6 +256,8 @@ public class OiyokanMessages {
     public static final String IY7152 = "[IY7152] NOT SUPPORTED: Edm Type";
     public static final String IY7153 = "[IY7153] NOT SUPPORTED: JDBC Type String.";
     public static final String IY7154 = "[IY7154] NOT SUPPORTED: JDBC Type";
+    public static final String IY7155 = "[IY7155] NOT SUPPORTED: JDBC Connection transaction isolation";
+    public static final String IY7156 = "[IY7156] NOT SUPPORTED: JDBC Connection transaction isolation string";
 
     public static final String IY7160 = "[IY7160] Error: Fail to parse Time string.";
     public static final String IY7161 = "[IY7161] Error: Fail to parse DateTime string.";
@@ -267,6 +269,7 @@ public class OiyokanMessages {
     public static final String IY7172 = "[IY7172] INFO: setup oiyokanKan database";
     public static final String IY7173 = "[IY7173] INFO: start to load oiyokan settings";
     public static final String IY7174 = "[IY7174] INFO: load oiyokan settings";
+    public static final String IY7175 = "[IY7175] DEBUG: DB set connection transaction isolation.";
 
     ////////////////////////////////////////////////////////////////////////////////
     // Authz (Server Side)

--- a/src/main/java/jp/oiyokan/common/OiyoCommonJdbcUtil.java
+++ b/src/main/java/jp/oiyokan/common/OiyoCommonJdbcUtil.java
@@ -103,8 +103,16 @@ public class OiyoCommonJdbcUtil {
                 conn = DriverManager.getConnection(settingsDatabase.getJdbcUrl(), settingsDatabase.getJdbcUser(),
                         settingsDatabase.getJdbcPassPlain());
             }
-            // TRANSACTION_READ_COMMITTED を設定.
-            conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+
+            if (settingsDatabase.getTransactionIsolation() != null
+                    && settingsDatabase.getTransactionIsolation().length() > 0) {
+                // [IY7175] DEBUG: DB set connection transaction isolation.
+                log.debug(OiyokanMessages.IY7175 + ": " + settingsDatabase.getTransactionIsolation());
+
+                final int transactionIsolation = OiyoJdbcUtil
+                        .string2TransactionIsolation(settingsDatabase.getTransactionIsolation());
+                conn.setTransactionIsolation(transactionIsolation);
+            }
         } catch (SQLException ex) {
             // [M005] UNEXPECTED: データベースの接続に失敗:
             // しばらく待って再度トライしてください。しばらく経っても改善しない場合はIT部門に連絡してください

--- a/src/main/java/jp/oiyokan/common/OiyoCommonJdbcUtil.java
+++ b/src/main/java/jp/oiyokan/common/OiyoCommonJdbcUtil.java
@@ -21,6 +21,7 @@ import java.io.Reader;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -112,6 +113,27 @@ public class OiyoCommonJdbcUtil {
                 final int transactionIsolation = OiyoJdbcUtil
                         .string2TransactionIsolation(settingsDatabase.getTransactionIsolation());
                 conn.setTransactionIsolation(transactionIsolation);
+            }
+
+            if (settingsDatabase.getInitSqlExec() != null && settingsDatabase.getInitSqlExec().trim().length() > 0) {
+                // [IY7176] DEBUG: DB init sql exec.
+                log.debug(OiyokanMessages.IY7176 + ": " + settingsDatabase.getInitSqlExec());
+
+                try (PreparedStatement stmt = conn.prepareStatement(settingsDatabase.getInitSqlExec())) {
+                    final boolean hasResultSet = stmt.execute();
+                    if (hasResultSet) {
+                        try (ResultSet rs = stmt.getResultSet()) {
+                            ResultSetMetaData rsmeta = rs.getMetaData();
+                            int columnCount = rsmeta.getColumnCount();
+                            for (; rs.next();) {
+                                log.trace("  row:");
+                                for (int column = 1; column <= columnCount; column++) {
+                                    log.trace("    " + rsmeta.getColumnName(column) + ": " + rs.getString(column));
+                                }
+                            }
+                        }
+                    }
+                }
             }
         } catch (SQLException ex) {
             // [M005] UNEXPECTED: データベースの接続に失敗:

--- a/src/main/java/jp/oiyokan/dto/OiyoSettingsDatabase.java
+++ b/src/main/java/jp/oiyokan/dto/OiyoSettingsDatabase.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "name", "type", "description", "jdbcDriver", "jdbcUrl", "jdbcUser", "jdbcPassEnc", "jdbcPassPlain",
-        "transactionIsolation" })
+        "transactionIsolation", "initSqlExec" })
 @Generated("jsonschema2pojo")
 public class OiyoSettingsDatabase implements Serializable {
     private static final long serialVersionUID = 1L;
@@ -58,6 +58,8 @@ public class OiyoSettingsDatabase implements Serializable {
     private String jdbcPassPlain;
     @JsonProperty("transactionIsolation")
     private String transactionIsolation;
+    @JsonProperty("initSqlExec")
+    private String initSqlExec;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
@@ -149,6 +151,16 @@ public class OiyoSettingsDatabase implements Serializable {
     @JsonProperty("transactionIsolation")
     public void setTransactionIsolation(String transactionIsolation) {
         this.transactionIsolation = transactionIsolation;
+    }
+
+    @JsonProperty("initSqlExec")
+    public String getInitSqlExec() {
+        return initSqlExec;
+    }
+
+    @JsonProperty("initSqlExec")
+    public void setInitSqlExec(String initSqlExec) {
+        this.initSqlExec = initSqlExec;
     }
 
     @JsonAnyGetter

--- a/src/main/java/jp/oiyokan/dto/OiyoSettingsDatabase.java
+++ b/src/main/java/jp/oiyokan/dto/OiyoSettingsDatabase.java
@@ -34,8 +34,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * http://www.jsonschema2pojo.org/ を利用して自動生成.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "name", "type", "description", "jdbcDriver", "jdbcUrl", "jdbcUser", "jdbcPassEnc",
-        "jdbcPassPlain" })
+@JsonPropertyOrder({ "name", "type", "description", "jdbcDriver", "jdbcUrl", "jdbcUser", "jdbcPassEnc", "jdbcPassPlain",
+        "transactionIsolation" })
 @Generated("jsonschema2pojo")
 public class OiyoSettingsDatabase implements Serializable {
     private static final long serialVersionUID = 1L;
@@ -56,6 +56,8 @@ public class OiyoSettingsDatabase implements Serializable {
     private String jdbcPassEnc;
     @JsonProperty("jdbcPassPlain")
     private String jdbcPassPlain;
+    @JsonProperty("transactionIsolation")
+    private String transactionIsolation;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
@@ -137,6 +139,16 @@ public class OiyoSettingsDatabase implements Serializable {
     @JsonProperty("jdbcPassPlain")
     public void setJdbcPassPlain(String jdbcPassPlain) {
         this.jdbcPassPlain = jdbcPassPlain;
+    }
+
+    @JsonProperty("transactionIsolation")
+    public String getTransactionIsolation() {
+        return transactionIsolation;
+    }
+
+    @JsonProperty("transactionIsolation")
+    public void setTransactionIsolation(String transactionIsolation) {
+        this.transactionIsolation = transactionIsolation;
     }
 
     @JsonAnyGetter

--- a/src/main/java/jp/oiyokan/util/OiyoJdbcUtil.java
+++ b/src/main/java/jp/oiyokan/util/OiyoJdbcUtil.java
@@ -15,6 +15,7 @@
  */
 package jp.oiyokan.util;
 
+import java.sql.Connection;
 import java.sql.Types;
 
 import org.apache.commons.logging.Log;
@@ -252,6 +253,47 @@ public class OiyoJdbcUtil {
         // [IY7153] NOT SUPPORTED: JDBC Type String.
         log.error(OiyokanMessages.IY7153 + ": " + typesString);
         throw new IllegalArgumentException(OiyokanMessages.IY7153 + ": " + typesString);
+    }
+
+    public static String transactionIsolation2String(int transactionIsolation) {
+        switch (transactionIsolation) {
+        case Connection.TRANSACTION_NONE:
+            return "Connection.TRANSACTION_NONE";
+        case Connection.TRANSACTION_READ_UNCOMMITTED:
+            return "Connection.TRANSACTION_READ_UNCOMMITTED";
+        case Connection.TRANSACTION_READ_COMMITTED:
+            return "Connection.TRANSACTION_READ_COMMITTED";
+        case Connection.TRANSACTION_REPEATABLE_READ:
+            return "Connection.TRANSACTION_REPEATABLE_READ";
+        case Connection.TRANSACTION_SERIALIZABLE:
+            return "Connection.TRANSACTION_SERIALIZABLE";
+        }
+
+        // [IY7155] NOT SUPPORTED: JDBC Connection transaction isolation
+        log.error(OiyokanMessages.IY7155 + ": " + transactionIsolation);
+        throw new IllegalArgumentException(OiyokanMessages.IY7155 + ": " + transactionIsolation);
+    }
+
+    public static int string2TransactionIsolation(String transactionIsolation) {
+        if ("Connection.TRANSACTION_NONE".equals(transactionIsolation)) {
+            return Connection.TRANSACTION_NONE;
+        }
+        if ("Connection.TRANSACTION_READ_UNCOMMITTED".equals(transactionIsolation)) {
+            return Connection.TRANSACTION_READ_UNCOMMITTED;
+        }
+        if ("Connection.TRANSACTION_READ_COMMITTED".equals(transactionIsolation)) {
+            return Connection.TRANSACTION_READ_COMMITTED;
+        }
+        if ("Connection.TRANSACTION_REPEATABLE_READ".equals(transactionIsolation)) {
+            return Connection.TRANSACTION_REPEATABLE_READ;
+        }
+        if ("Connection.TRANSACTION_SERIALIZABLE".equals(transactionIsolation)) {
+            return Connection.TRANSACTION_SERIALIZABLE;
+        }
+
+        // [IY7156] NOT SUPPORTED: JDBC Connection transaction isolation string
+        log.error(OiyokanMessages.IY7156 + ": " + transactionIsolation);
+        throw new IllegalArgumentException(OiyokanMessages.IY7156 + ": " + transactionIsolation);
     }
 
     /**

--- a/src/main/resources/oiyokan/oiyokanKan-settings.json
+++ b/src/main/resources/oiyokan/oiyokanKan-settings.json
@@ -11,7 +11,8 @@
       "jdbcUser": "sa",
       "jdbcPassEnc": "Ckg+Af2U4q9FgV+TnUTPoA==",
       "jdbcPassPlain": "",
-      "transactionIsolation": "Connection.TRANSACTION_READ_COMMITTED"
+      "transactionIsolation": "Connection.TRANSACTION_READ_COMMITTED",
+      "initSqlExec": ""
     }
   ],
   "entitySet": [

--- a/src/main/resources/oiyokan/oiyokanKan-settings.json
+++ b/src/main/resources/oiyokan/oiyokanKan-settings.json
@@ -10,7 +10,8 @@
       "jdbcUrl": "jdbc:h2:mem:oiyokan;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=FALSE;MODE=MSSQLServer",
       "jdbcUser": "sa",
       "jdbcPassEnc": "Ckg+Af2U4q9FgV+TnUTPoA==",
-      "jdbcPassPlain": ""
+      "jdbcPassPlain": "",
+      "transactionIsolation": "Connection.TRANSACTION_READ_COMMITTED"
     }
   ],
   "entitySet": [

--- a/src/test/java/jp/oiyokan/util/OiyoJdbcUtilTest.java
+++ b/src/test/java/jp/oiyokan/util/OiyoJdbcUtilTest.java
@@ -17,6 +17,7 @@ package jp.oiyokan.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.sql.Connection;
 import java.sql.Types;
 
 import org.junit.jupiter.api.Test;
@@ -68,8 +69,15 @@ class OiyoJdbcUtilTest {
             , Types.TIMESTAMP_WITH_TIMEZONE // 2014
     };
 
+    private static final int[] TRANSACTIONS = { //
+            Connection.TRANSACTION_NONE //
+            , Connection.TRANSACTION_READ_UNCOMMITTED //
+            , Connection.TRANSACTION_READ_COMMITTED //
+            , Connection.TRANSACTION_REPEATABLE_READ //
+            , Connection.TRANSACTION_SERIALIZABLE };
+
     @Test
-    void test() {
+    void testTypes() {
         for (int origin : TYPES) {
             String val = OiyoJdbcUtil.types2String(origin);
             int result = OiyoJdbcUtil.string2Types(val);
@@ -77,4 +85,12 @@ class OiyoJdbcUtilTest {
         }
     }
 
+    @Test
+    void testTransactionIsolation() {
+        for (int origin : TRANSACTIONS) {
+            String val = OiyoJdbcUtil.transactionIsolation2String(origin);
+            int result = OiyoJdbcUtil.string2TransactionIsolation(val);
+            assertEquals(origin, result);
+        }
+    }
 }

--- a/src/test/resources/oiyokan/oiyokan-unittest-settings.json
+++ b/src/test/resources/oiyokan/oiyokan-unittest-settings.json
@@ -10,7 +10,8 @@
       "jdbcUrl": "jdbc:h2:mem:oiyoUnitTestDb;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=FALSE;MODE=MSSQLServer",
       "jdbcUser": "sa",
       "jdbcPassEnc": "Ckg+Af2U4q9FgV+TnUTPoA==",
-      "jdbcPassPlain": ""
+      "jdbcPassPlain": "",
+      "transactionIsolation": "Connection.TRANSACTION_READ_COMMITTED"
     }
   ],
   "entitySet": [


### PR DESCRIPTION
# Release 1.16 (2021-05-22)

## EN

- Added field named transactionIsolation to JSON to configure isolation level like Connection.setTransactionIsolation.
- Added field named initSqlExec to JSON to specify the initialization SQL statement at the time of DB connection (experimental).

## JA

- transactionIsolation という名前の項目を JSON に追加して Connection.setTransactionIsolation などを指定できるように変更。
- initSqlExec という名前の項目を JSON に追加して DB接続時の初期化SQL文を指定できるようにする (experimental)。