### PR TITLE
いくつかの小さな機能強化

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,11 @@
 
 ## JA
 
+
+- JSON params are added. autoCommit, jdbcFetchSize, filterEqAutoSelect
+- 一覧取得ent(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
+                : connTargetDb.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY))) {
+                
 - パラメータなしクエリは java.sql.Statement を利用する 
 - 上記: 各DBで確認済み
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,18 +1,17 @@
-# Release 1.17 (2021-05-??)
+# Release 1.17 (2021-05-25)
 
 ## EN
 
+- Some JSON params are added to `oiyokan-settings.json`: autoCommit, jdbcFetchSize, filterEqAutoSelect。
+- Added ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY to collection Statement.
 - Use java.sql.Statement for parameterless queries.
 
 ## JA
 
-
-- JSON params are added. autoCommit, jdbcFetchSize, filterEqAutoSelect
-- 一覧取得ent(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
-                : connTargetDb.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY))) {
-                
-- パラメータなしクエリは java.sql.Statement を利用する 
-- 上記: 各DBで確認済み
+- `oiyokan-settings.json` にいくつかの JSON パラメータを追加: autoCommit, jdbcFetchSize, filterEqAutoSelect。
+- 一覧取得Statementに ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY 指定を追加。
+- パラメータなしクエリは java.sql.Statement を利用。
+- 上記: 各DBで確認済み。
 
 # Release 1.16 (2021-05-22)
 

--- a/doc/spec-oiyokan-settings.md
+++ b/doc/spec-oiyokan-settings.md
@@ -39,7 +39,8 @@ src/main/resources/iyokan/oiyokan-settings.json
 | jdbcUser       | JDBC user name. ex: `user1`                                       |
 | jdbcPassEnc    | JDBC password with Encryption. (Recommended)                      |
 | jdbcPassPlain  | JDBC password without Encryption. (jdbcPassEnc is recommended)    |
-| transactionIsolation | Transaction Isolation. Default:`Connection.TRANSACTION_READ_COMMITTED` |
+| autoCommit     | call setAutoCommit if value is set: Default: `null`           |
+| transactionIsolation | Transaction Isolation. Default: `Connection.TRANSACTION_READ_COMMITTED` |
 | initSqlExec    | (experimental) Initialize sql when connect.                       |
 
 #### entitySet section
@@ -49,12 +50,14 @@ src/main/resources/iyokan/oiyokan-settings.json
 | name           | Name of EntitySet.                                                |
 | description    | Description of this EntitySet.                                    |
 | dbSettingName  | Name of database setting.                                         |
-| canCreate      | CRUD authz of Create. Default:`true`.                             |
-| canRead        | CRUD authz of Read. true supported only. Default:`true`.          |
-| canUpdate      | CRUD authz of Update. Default:`true`.                             |
-| canDelete      | CRUD authz of Delete. Default:`true`.                             |
-| omitCountAll   | Ignore `$count` in the case of NO conditional query. Default:`false`. |
+| canCreate      | CRUD authz of Create. Default: `true`.                             |
+| canRead        | CRUD authz of Read. true supported only. Default: `true`.          |
+| canUpdate      | CRUD authz of Update. Default: `true`.                             |
+| canDelete      | CRUD authz of Delete. Default: `true`.                             |
+| omitCountAll   | Ignore `$count` in the case of NO conditional query. Default: `false`. |
 | jdbcStmtTimeout | Timeout seconds. Default:'30'                                    |
+| jdbcFetchSize  | Call setFetchSize if value is set. Default: `null`         |
+| filterEqAutoSelect | (experimental) Auto select property if `$filter` specify property with eq. Defalut: `null`   |
 | entityType     | List of entityType.                                               |
 
 #### entityType - sub section
@@ -75,13 +78,13 @@ src/main/resources/iyokan/oiyokan-settings.json
 | edmType        | Column name on Database. ex: `Edm.String`                         |
 | dbType         | Type name on Database. ex: `VARCHAR`                              |
 | jdbcSetMethod  | (reserved) Hint method name of JDBC API. ex: `setString`          |
-| autoGenKey     | Set true if this property is auto generated key. Default:`false`  |
-| nullable       | true:Nullable, false:NOT NULL, null:Unknown. Default:`true`.      |
+| autoGenKey     | Set true if this property is auto generated key. Default: `false`  |
+| nullable       | true:Nullable, false:NOT NULL, null:Unknown. Default: `true`.      |
 | maxLength      | Length of string field.                                           |
-| lengthFixed    | Set field fixed. For CHAR type. Default:`false`.                  |
-| precision      | precision of decimal. Default:`null`.                             |
-| scale          | scale of decimal. Default:`null`.                                 |
-| dbDefault      | Default value of database. Default:`null`.                        |
-| filterTreatNullAsBlank | Treat property (String) value null as blank. Default:`false`. |
+| lengthFixed    | Set field fixed. For CHAR type. Default: `false`.                  |
+| precision      | precision of decimal. Default: `null`.                             |
+| scale          | scale of decimal. Default: `null`.                                 |
+| dbDefault      | Default value of database. Default: `null`.                        |
+| filterTreatNullAsBlank | Treat property (String) value null as blank. Default: `false`. |
 
 via: [diary](https://raw.githubusercontent.com/igapyon/diary/devel/2021/ig210426.src.md)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>jp.igapyon.oiyokan</groupId>
 	<artifactId>oiyokan</artifactId>
-	<version>1.16.20210524e-SNAPSHOT</version>
+	<version>1.16.20210525d-SNAPSHOT</version>
 	<name>oiyokan</name>
 	<description>Oiyokan is a simple OData v4 Server. (based on Apache
 		Olingo / h2 database)</description>

--- a/src/main/java/jp/oiyokan/OiyokanConstants.java
+++ b/src/main/java/jp/oiyokan/OiyokanConstants.java
@@ -27,7 +27,7 @@ public class OiyokanConstants {
     /**
      * Oiyokan のバージョン番号
      */
-    public static final String VERSION = "1.16.20210524e";
+    public static final String VERSION = "1.16.20210525d";
 
     /**
      * 暗号化で利用するパスフレーズ。環境変数 OIYOKAN_PASSPHRASE で上書き動作。

--- a/src/main/java/jp/oiyokan/OiyokanEntityCollectionProcessor.java
+++ b/src/main/java/jp/oiyokan/OiyokanEntityCollectionProcessor.java
@@ -50,6 +50,7 @@ import org.apache.olingo.server.core.uri.validator.UriValidationException;
 import jp.oiyokan.basic.OiyoBasicJdbcEntityCollectionBuilder;
 import jp.oiyokan.common.OiyoInfo;
 import jp.oiyokan.common.OiyoInfoUtil;
+import jp.oiyokan.dto.OiyoSettingsEntitySet;
 
 /**
  * Oiyokan による EntityCollectionProcessor 実装.
@@ -140,11 +141,13 @@ public class OiyokanEntityCollectionProcessor implements EntityCollectionProcess
             }
             if (uriInfo.getSelectOption() != null) {
                 // $select あり.
-                if (eCollection.getEntities().size() == 0) {
+                final OiyoSettingsEntitySet entitySet = OiyoInfoUtil.getOiyoEntitySet(oiyoInfo, edmEntitySet.getName());
+
+                if (eCollection.getEntities().size() == 0 //
+                        || (entitySet.getFilterEqAutoSelect() == null || !entitySet.getFilterEqAutoSelect())) {
                     builder.select(uriInfo.getSelectOption());
                 } else {
                     // ここにはEQ対象項目を$selectに自動で加える特殊モードが実装されている。
-                    // TODO v2.x EQで自動$selectはフラグでON/OFFできるようすること。
                     String propNames = "";
                     for (int index = 0; index < eCollection.getEntities().size(); index++) {
                         for (Property prop : eCollection.getEntities().get(index).getProperties()) {

--- a/src/main/java/jp/oiyokan/basic/OiyoBasicJdbcEntityCollectionBuilder.java
+++ b/src/main/java/jp/oiyokan/basic/OiyoBasicJdbcEntityCollectionBuilder.java
@@ -182,8 +182,8 @@ public class OiyoBasicJdbcEntityCollectionBuilder implements OiyokanEntityCollec
         int countWithWhere = 0;
         final long startMillisec = System.currentTimeMillis();
         try (var stmt = (basicSqlBuilder.getSqlInfo().getSqlParamList().size() == 0 //
-                ? connTargetDb.createStatement()
-                : connTargetDb.prepareStatement(sql))) {
+                ? connTargetDb.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
+                : connTargetDb.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY))) {
             final int jdbcStmtTimeout = (entitySet.getJdbcStmtTimeout() == null ? 30 : entitySet.getJdbcStmtTimeout());
             stmt.setQueryTimeout(jdbcStmtTimeout);
 
@@ -290,8 +290,12 @@ public class OiyoBasicJdbcEntityCollectionBuilder implements OiyokanEntityCollec
 
         final long startMillisec = System.currentTimeMillis();
         try (var stmt = (basicSqlBuilder.getSqlInfo().getSqlParamList().size() == 0 //
-                ? connTargetDb.createStatement()
-                : connTargetDb.prepareStatement(sql))) {
+                ? connTargetDb.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
+                : connTargetDb.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY))) {
+            if (entitySet.getJdbcFetchSize() != null) {
+                stmt.setFetchSize(entitySet.getJdbcFetchSize());
+            }
+
             final int jdbcStmtTimeout = (entitySet.getJdbcStmtTimeout() == null ? 30 : entitySet.getJdbcStmtTimeout());
             stmt.setQueryTimeout(jdbcStmtTimeout);
 

--- a/src/main/java/jp/oiyokan/common/OiyoCommonJdbcUtil.java
+++ b/src/main/java/jp/oiyokan/common/OiyoCommonJdbcUtil.java
@@ -105,6 +105,11 @@ public class OiyoCommonJdbcUtil {
                         settingsDatabase.getJdbcPassPlain());
             }
 
+            if (settingsDatabase.getAutoCommit() != null) {
+                // TODO message
+                conn.setAutoCommit(settingsDatabase.getAutoCommit());
+            }
+
             if (settingsDatabase.getTransactionIsolation() != null
                     && settingsDatabase.getTransactionIsolation().length() > 0) {
                 // [IY7175] DEBUG: DB set connection transaction isolation.

--- a/src/main/java/jp/oiyokan/dto/OiyoSettingsDatabase.java
+++ b/src/main/java/jp/oiyokan/dto/OiyoSettingsDatabase.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "name", "type", "description", "jdbcDriver", "jdbcUrl", "jdbcUser", "jdbcPassEnc", "jdbcPassPlain",
-        "transactionIsolation", "initSqlExec" })
+        "autoCommit", "transactionIsolation", "initSqlExec" })
 @Generated("jsonschema2pojo")
 public class OiyoSettingsDatabase implements Serializable {
     private static final long serialVersionUID = 1L;
@@ -56,6 +56,8 @@ public class OiyoSettingsDatabase implements Serializable {
     private String jdbcPassEnc;
     @JsonProperty("jdbcPassPlain")
     private String jdbcPassPlain;
+    @JsonProperty("autoCommit")
+    private Boolean autoCommit;
     @JsonProperty("transactionIsolation")
     private String transactionIsolation;
     @JsonProperty("initSqlExec")
@@ -141,6 +143,16 @@ public class OiyoSettingsDatabase implements Serializable {
     @JsonProperty("jdbcPassPlain")
     public void setJdbcPassPlain(String jdbcPassPlain) {
         this.jdbcPassPlain = jdbcPassPlain;
+    }
+
+    @JsonProperty("autoCommit")
+    public Boolean getAutoCommit() {
+        return autoCommit;
+    }
+
+    @JsonProperty("autoCommit")
+    public void setAutoCommit(Boolean autoCommit) {
+        this.autoCommit = autoCommit;
     }
 
     @JsonProperty("transactionIsolation")

--- a/src/main/java/jp/oiyokan/dto/OiyoSettingsEntitySet.java
+++ b/src/main/java/jp/oiyokan/dto/OiyoSettingsEntitySet.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "name", "description", "dbSettingName", "canCreate", "canRead", "canUpdate", "canDelete",
-        "omitCountAll", "jdbcStmtTimeout", "entityType" })
+        "omitCountAll", "jdbcStmtTimeout", "jdbcFetchSize", "filterEqAutoSelect", "entityType" })
 @Generated("jsonschema2pojo")
 public class OiyoSettingsEntitySet implements Serializable {
     private static final long serialVersionUID = 1L;
@@ -58,6 +58,10 @@ public class OiyoSettingsEntitySet implements Serializable {
     private Boolean omitCountAll;
     @JsonProperty("jdbcStmtTimeout")
     private Integer jdbcStmtTimeout;
+    @JsonProperty("jdbcFetchSize")
+    private Integer jdbcFetchSize;
+    @JsonProperty("filterEqAutoSelect")
+    private Boolean filterEqAutoSelect;
     @JsonProperty("entityType")
     private OiyoSettingsEntityType entityType;
     @JsonIgnore
@@ -151,6 +155,26 @@ public class OiyoSettingsEntitySet implements Serializable {
     @JsonProperty("jdbcStmtTimeout")
     public void setJdbcStmtTimeout(Integer jdbcStmtTimeout) {
         this.jdbcStmtTimeout = jdbcStmtTimeout;
+    }
+
+    @JsonProperty("jdbcFetchSize")
+    public Integer getJdbcFetchSize() {
+        return jdbcFetchSize;
+    }
+
+    @JsonProperty("jdbcFetchSize")
+    public void setJdbcFetchSize(Integer jdbcFetchSize) {
+        this.jdbcFetchSize = jdbcFetchSize;
+    }
+
+    @JsonProperty("filterEqAutoSelect")
+    public Boolean getFilterEqAutoSelect() {
+        return filterEqAutoSelect;
+    }
+
+    @JsonProperty("filterEqAutoSelect")
+    public void setFilterEqAutoSelect(Boolean filterEqAutoSelect) {
+        this.filterEqAutoSelect = filterEqAutoSelect;
     }
 
     @JsonProperty("entityType")

--- a/src/main/resources/oiyokan/oiyokanKan-settings.json
+++ b/src/main/resources/oiyokan/oiyokanKan-settings.json
@@ -11,6 +11,7 @@
       "jdbcUser": "sa",
       "jdbcPassEnc": "Ckg+Af2U4q9FgV+TnUTPoA==",
       "jdbcPassPlain": "",
+      "autoCommit": false,
       "transactionIsolation": "Connection.TRANSACTION_READ_COMMITTED",
       "initSqlExec": ""
     }
@@ -26,6 +27,8 @@
       "canDelete": false,
       "omitCountAll": false,
       "jdbcStmtTimeout": 30,
+      "jdbcFetchSize": 100,
+      "filterEqAutoSelect": false,
       "entityType": {
         "name": "Oiyokan",
         "dbName": "Oiyokan",

--- a/src/test/java/jp/oiyokan/db/testdb/entity/UnitTestTypeChar01Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/entity/UnitTestTypeChar01Test.java
@@ -53,8 +53,10 @@ class UnitTestTypeChar01Test {
         /// 通常のfilter
         resp = OiyokanTestUtil.callGet("/ODataTest3", "$filter=ID eq " + idString + "&$select=StringChar8");
         result = OiyokanTestUtil.stream2String(resp.getContent());
-        assertEquals("{\"@odata.context\":\"$metadata#ODataTest3\",\"value\":[{\"ID\":" + idString
-                + ",\"StringChar8\":\"  C456  \"}]}", result, "前後空白付きでFILTER検索できることを確認.");
+        assertEquals(
+                "{\"@odata.context\":\"$metadata#ODataTest3\",\"value\":[{\"@odata.id\":\"ODataTest3(" + idString
+                        + ")\",\"ID\":" + idString + ",\"StringChar8\":\"  C456  \"}]}",
+                result, "前後空白付きでFILTER検索できることを確認.");
         assertEquals(200, resp.getStatusCode());
 
         // DELETE

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery03Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery03Test.java
@@ -43,8 +43,7 @@ class UnitTestQuery03Test {
 
         switch (databaseType) {
         default:
-            assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Boolean1\":false}]}",
-                    result);
+            assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1}]}", result);
             assertEquals(200, resp.getStatusCode());
             break;
         case ORCL18:

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery04Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery04Test.java
@@ -38,7 +38,7 @@ class UnitTestQuery04Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Int16a\":32767}]}", result);
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1}]}", result);
         assertEquals(200, resp.getStatusCode());
     }
 }

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery05Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery05Test.java
@@ -39,9 +39,7 @@ class UnitTestQuery05Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Int32a\":2147483647},{\"ID\":2,\"Int32a\":2147483647}]}",
-                result);
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1},{\"ID\":2}]}", result);
         assertEquals(200, resp.getStatusCode());
     }
 }

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery06Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery06Test.java
@@ -39,9 +39,7 @@ class UnitTestQuery06Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":3,\"Int64a\":2147483647},{\"ID\":4,\"Int64a\":2147483647}]}",
-                result);
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":3},{\"ID\":4}]}", result);
         assertEquals(200, resp.getStatusCode());
     }
 }

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery07Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery07Test.java
@@ -38,9 +38,7 @@ class UnitTestQuery07Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":3,\"Decimal1\":1234.56},{\"ID\":4,\"Decimal1\":1234.56}]}",
-                result);
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":3},{\"ID\":4}]}", result);
         assertEquals(200, resp.getStatusCode());
     }
 }

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery08Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery08Test.java
@@ -38,7 +38,7 @@ class UnitTestQuery08Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Sbyte1\":127}]}", result);
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1}]}", result);
         assertEquals(200, resp.getStatusCode());
     }
 }

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery09Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery09Test.java
@@ -45,8 +45,7 @@ class UnitTestQuery09Test {
 
         switch (databaseType) {
         default:
-            assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Single1\":123.45}]}",
-                    result, "Single型の確認");
+            assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1}]}", result, "Single型の確認");
             assertEquals(200, resp.getStatusCode());
             break;
         case PostgreSQL:

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery11Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery11Test.java
@@ -39,8 +39,7 @@ class UnitTestQuery11Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204,\"StringVar255\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"}]}",
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204}]}",
                 result);
         assertEquals(200, resp.getStatusCode());
     }

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery12Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery12Test.java
@@ -53,8 +53,7 @@ class UnitTestQuery12Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204,\"StringVar255\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\",\"StringLongVar1\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\",\"Clob1\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"}]}",
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204}]}",
                 result, "検索できることの確認.");
         assertEquals(200, resp.getStatusCode());
     }

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery13Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery13Test.java
@@ -39,8 +39,7 @@ class UnitTestQuery13Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204,\"StringLongVar1\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"}]}",
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204}]}",
                 result);
         assertEquals(200, resp.getStatusCode());
     }

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery14Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQuery14Test.java
@@ -53,8 +53,7 @@ class UnitTestQuery14Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204,\"Clob1\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"}]}",
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204}]}",
                 result, "検索できることの確認.");
         assertEquals(200, resp.getStatusCode());
     }

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQueryBinaryEq01Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQueryBinaryEq01Test.java
@@ -40,9 +40,7 @@ class UnitTestQueryBinaryEq01Test {
                 OiyoUrlUtil.encodeUrlQuery("&$filter=Int32a eq Int64a &$top=2 &$select=ID &$orderby=ID asc"));
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Int32a\":2147483647,\"Int64a\":2147483647},{\"ID\":2,\"Int32a\":2147483647,\"Int64a\":2147483647}]}",
-                result);
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1},{\"ID\":2}]}", result);
         assertEquals(200, resp.getStatusCode());
     }
 }

--- a/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQueryBinaryEq02Test.java
+++ b/src/test/java/jp/oiyokan/db/testdb/query/UnitTestQueryBinaryEq02Test.java
@@ -40,8 +40,7 @@ class UnitTestQueryBinaryEq02Test {
                 OiyoUrlUtil.encodeUrlQuery("&$filter=32767 eq Int16a &$top=3 &$select=ID &$orderby=ID asc"));
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Int16a\":32767},{\"ID\":2,\"Int16a\":32767},{\"ID\":3,\"Int16a\":32767}]}",
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1},{\"ID\":2},{\"ID\":3}]}",
                 result);
         assertEquals(200, resp.getStatusCode());
     }


### PR DESCRIPTION
- `oiyokan-settings.json` にいくつかの JSON パラメータを追加: autoCommit, jdbcFetchSize, filterEqAutoSelect。
- 一覧取得Statementに ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY 指定を追加。
- パラメータなしクエリは java.sql.Statement を利用。