### PR TITLE
Tiga

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,13 @@
+# Release 1.20 (2021-06-13)
+
+## EN
+
+- Fixed an issue that caused h2 and SQL Server to malfunction when Oiyokan was run with Database "autoCommit": false.
+
+## JA
+
+- Oiyokan を Database "autoCommit": false で動作させた際に h2 および SQL Server で動作不良を起こす問題を修正。
+
 # Release 1.19 (2021-06-03)
 
 ## EN

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>jp.igapyon.oiyokan</groupId>
 	<artifactId>oiyokan</artifactId>
-	<version>1.19.20210603b-SNAPSHOT</version>
+	<version>1.19.20210613a-SNAPSHOT</version>
 	<name>oiyokan</name>
 	<description>Oiyokan is a simple OData v4 Server. (based on Apache
 		Olingo / h2 database)</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>jp.igapyon.oiyokan</groupId>
 	<artifactId>oiyokan</artifactId>
-	<version>1.19.20210613a-SNAPSHOT</version>
+	<version>1.20.20210613a-SNAPSHOT</version>
 	<name>oiyokan</name>
 	<description>Oiyokan is a simple OData v4 Server. (based on Apache
 		Olingo / h2 database)</description>

--- a/src/main/java/jp/oiyokan/basic/OiyoBasicJdbcEntityOneBuilder.java
+++ b/src/main/java/jp/oiyokan/basic/OiyoBasicJdbcEntityOneBuilder.java
@@ -213,7 +213,7 @@ public class OiyoBasicJdbcEntityOneBuilder {
         try (Connection connTargetDb = OiyoCommonJdbcUtil.getConnection(database)) {
             log.trace("[database transaction] BEGIN database transaction.");
             if (database.getAutoCommit() == null || database.getAutoCommit()) {
-                // autoCommit 指定なし、または、true の場合、autoCommitをfalseに設定.
+                // autoCommit 指定なし、または、true の場合、トランザクションを開始させるために autoCommitをfalseに設定.
                 log.trace("conn.setAutoCommit(false)");
                 connTargetDb.setAutoCommit(false);
             }
@@ -295,7 +295,7 @@ public class OiyoBasicJdbcEntityOneBuilder {
 
                 log.trace("[database transaction] END database transaction.");
                 if (database.getAutoCommit() == null || database.getAutoCommit()) {
-                    // autoCommit 指定なし、または、true の場合、autoCommitをtrueに戻す。
+                    // autoCommit 指定なし、または、true の場合、トランザクションを終了させる目的のために autoCommitをtrueに戻す。
                     log.trace("conn.setAutoCommit(true)");
                     connTargetDb.setAutoCommit(true);
                 }


### PR DESCRIPTION
Release 1.20 (2021-06-13)

## EN

- Fixed an issue that caused h2 and SQL Server to malfunction when Oiyokan was run with Database "autoCommit": false.

## JA

- Oiyokan を Database "autoCommit": false で動作させた際に h2 および SQL Server で動作不良を起こす問題を修正。